### PR TITLE
Extension for protege-proof-based-justifications prover extension point

### DIFF
--- a/elk-protege/pom.xml
+++ b/elk-protege/pom.xml
@@ -89,6 +89,13 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>not.org.saa</groupId>
+			<artifactId>protege-proof-based-justifications</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<scope>provided</scope>

--- a/elk-protege/src/main/java/org/semanticweb/elk/protege/proof/ElkProverService.java
+++ b/elk-protege/src/main/java/org/semanticweb/elk/protege/proof/ElkProverService.java
@@ -1,0 +1,68 @@
+package org.semanticweb.elk.protege.proof;
+
+/*-
+ * #%L
+ * ELK Reasoner Protege Plug-in
+ * $Id:$
+ * $HeadURL:$
+ * %%
+ * Copyright (C) 2011 - 2017 Department of Computer Science, University of Oxford
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/** 
+ * Date: 27-02-2017
+ */
+
+import org.liveontologies.owlapi.proof.OWLProver;
+import org.protege.editor.owl.OWLEditorKit;
+import org.semanticweb.elk.owlapi.ElkProver;
+import org.semanticweb.elk.owlapi.ElkProverFactory;
+import org.semanticweb.elk.owlapi.ElkReasoner;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+
+import not.org.saa.protege.justifications.service.ProverService;
+
+public class ElkProverService extends ProverService {
+
+	@Override
+	public void initialise() throws Exception {
+	}
+
+	@Override
+	public void dispose() throws Exception {
+	}
+
+	@Override
+	public OWLProver getProver(OWLEditorKit ek) {
+		OWLProver proverElk = null;
+		OWLReasoner reasoner = ek.getOWLModelManager()
+				.getOWLReasonerManager().getCurrentReasoner();
+		if (reasoner instanceof ElkReasoner) {
+			proverElk = new ElkProver((ElkReasoner) reasoner);
+		}
+		else
+		{
+			ElkProverFactory factory = new ElkProverFactory();
+			proverElk = factory.createReasoner(ek.getModelManager().getActiveOntology());
+		}
+		return proverElk;
+	}
+
+	@Override
+	public String getName() {
+		return "Elk Prover";
+	}
+}

--- a/elk-protege/src/main/resources/plugin.xml
+++ b/elk-protege/src/main/resources/plugin.xml
@@ -21,5 +21,10 @@
    <name value="ELK Prover"/>
    <class value="org.semanticweb.elk.protege.proof.ElkProofService"/>
 </extension>
-    
+
+<extension id="elk.prover" point="not.org.saa.protege.justifications.ProverService">
+   <name value="ELK Prover Service"/>
+   <class value="org.semanticweb.elk.protege.proof.ElkProverService"/>
+</extension>
+
 </plugin>


### PR DESCRIPTION
This is an extension to provide protege-proof-based-justifications with elk prover facilities. One can use it with protege-explanation-interface project to present justifications based on proofs created by ELK Reasoner in Protege.